### PR TITLE
General updates

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -60,8 +60,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -62,8 +62,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/eventbus/pom.xml
+++ b/eventbus/pom.xml
@@ -51,8 +51,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -34,8 +34,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/inject/pom.xml
+++ b/inject/pom.xml
@@ -59,8 +59,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -55,8 +55,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/lifecycle/pom.xml
+++ b/lifecycle/pom.xml
@@ -45,8 +45,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/lifecycle/pom.xml
+++ b/lifecycle/pom.xml
@@ -35,6 +35,7 @@
 
     <!--
     TODO: Investigate 6.1.0 version update. http://smc.sourceforge.net/
+    Not on central, this version deployed manually to RSO 3rd party repo
     -->
     <dependency>
       <groupId>net.sf.smc</groupId>

--- a/marshal/pom.xml
+++ b/marshal/pom.xml
@@ -97,13 +97,12 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.4</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/marshal/pom.xml
+++ b/marshal/pom.xml
@@ -28,8 +28,8 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <jackson.version>1.9.12</jackson.version>
-    <jackson2.version>2.3.1</jackson2.version>
+    <jackson.version>1.9.13</jackson.version>
+    <jackson2.version>2.3.5</jackson2.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
 
   <properties>
     <dropwizard.version>0.7.1</dropwizard.version>
-    <slf4j.version>1.7.9</slf4j.version>
-    <sisu-guice.version>3.1.10</sisu-guice.version>
-    <powermock.version>1.5</powermock.version>
+    <slf4j.version>1.7.10</slf4j.version>
+    <sisu-guice.version>3.2.5</sisu-guice.version>
+    <powermock.version>1.6.1</powermock.version>
   </properties>
 
   <modules>
@@ -144,7 +144,7 @@
       <dependency>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-annotations</artifactId>
-        <version>1.9</version>
+        <version>1.13</version>
       </dependency>
 
       <dependency>
@@ -156,7 +156,7 @@
       <dependency>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.inject</artifactId>
-        <version>0.1.1</version>
+        <version>0.3.0.M1</version>
       </dependency>
 
       <dependency>
@@ -276,13 +276,13 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.5</version>
       </dependency>
 
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
       </dependency>
 
       <dependency>
@@ -361,19 +361,19 @@
       <dependency>
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-junit</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.2</version>
       </dependency>
 
       <dependency>
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-guice</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.2</version>
       </dependency>
 
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock</artifactId>
-        <version>1.38</version>
+        <version>1.38</version> <!-- Later versions depend on Jackson 2.4, so we'd need to update too -->
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
   <properties>
     <dropwizard.version>0.7.1</dropwizard.version>
-    <slf4j.version>1.7.6</slf4j.version>
+    <slf4j.version>1.7.9</slf4j.version>
     <sisu-guice.version>3.1.10</sisu-guice.version>
     <powermock.version>1.5</powermock.version>
   </properties>
@@ -114,13 +114,13 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
-        <version>1.0.13</version>
+        <version>1.1.2</version>
       </dependency>
 
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.0.13</version>
+        <version>1.1.2</version>
       </dependency>
 
       <dependency>
@@ -181,12 +181,6 @@
         <groupId>org.sonatype.sisu.inject</groupId>
         <artifactId>guice-servlet</artifactId>
         <version>${sisu-guice.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.sonatype.sisu.litmus</groupId>
-        <artifactId>litmus-testsupport</artifactId>
-        <version>1.9</version>
       </dependency>
 
       <dependency>
@@ -270,7 +264,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.4</version>
+        <version>1.4.7</version> <!-- Works on Java8 -->
       </dependency>
 
       <dependency>
@@ -591,8 +585,9 @@
       </plugin>
 
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
+        <groupId>org.eclipse.sisu</groupId>
         <artifactId>sisu-maven-plugin</artifactId>
+        <version>0.3.0.M1</version>
         <executions>
           <execution>
             <goals>
@@ -697,20 +692,6 @@
               <configuration>
                 <lifecycleMappingMetadata>
                   <pluginExecutions>
-                    <pluginExecution>
-                      <pluginExecutionFilter>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>sisu-maven-plugin</artifactId>
-                        <versionRange>[1.1,)</versionRange>
-                        <goals>
-                          <goal>main-index</goal>
-                          <goal>test-index</goal>
-                        </goals>
-                      </pluginExecutionFilter>
-                      <action>
-                        <execute/>
-                      </action>
-                    </pluginExecution>
                     <pluginExecution>
                       <pluginExecutionFilter>
                         <groupId>org.codehaus.mojo</groupId>

--- a/prefs/pom.xml
+++ b/prefs/pom.xml
@@ -34,8 +34,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -45,8 +45,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -34,9 +34,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty.orbit</groupId>
-      <artifactId>javax.servlet</artifactId>
-      <version>3.0.0.v201112011016</version>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
     </dependency>
 
     <dependency>

--- a/ssl/pom.xml
+++ b/ssl/pom.xml
@@ -44,8 +44,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -47,8 +47,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/thread/pom.xml
+++ b/thread/pom.xml
@@ -39,8 +39,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -54,8 +54,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
General updates:
* get rid of litmus dep, is part of goodies now
* make build work on Java8 (xstream 1.4.7)
* minor updates to some libs (logging)
* servlet api 3.1
* sisu-inject
* junit, cucumber etc
* goodies-marshal: using now latest dot releases of 1.9.x and 2.3.x