### PR TITLE
Improvements for Pax-Exam

### DIFF
--- a/testsupport/src/main/java/org/sonatype/sisu/litmus/testsupport/junit/index/package-info.java
+++ b/testsupport/src/main/java/org/sonatype/sisu/litmus/testsupport/junit/index/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2007-2014 Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+// additional schema declarations needed in Java7+ to match original behaviour
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://sonatype.com/xsd/litmus-testsupport/index/1.0", xmlns = { //
+@javax.xml.bind.annotation.XmlNs(namespaceURI = "http://sonatype.com/xsd/litmus-testsupport/index/1.0", prefix = "index") })
+package org.sonatype.sisu.litmus.testsupport.junit.index;
+


### PR DESCRIPTION
* Support overriding of the test directory when integrating with launchers like Pax-Exam
* Fix XML generation on Java7+ to avoid spurious 'ns2' prefix (which can affect the XSL)
* Handle recording of links where the file doesn't yet exist, but parent directory does